### PR TITLE
feat(php): command run with current version

### DIFF
--- a/src/Processes/ProcessManager.php
+++ b/src/Processes/ProcessManager.php
@@ -17,7 +17,7 @@ class ProcessManager
         int $sleep,
         int $tries
     ): int {
-        $command = 'php artisan queue:work';
+        $command = PHP_BINARY . ' artisan queue:work';
 
         if (null !== $connection) {
             $command .= ' ' . $connection;


### PR DESCRIPTION
In case we has apps running with php `7.2` and `7.3` we can set schedule:run with:

`/opt/plesk/php/7.2/bin/php /var/www/vhosts/mixdinternet.com.br/app1.com.br/artisan schedule:run`

`/opt/plesk/php/7.3/bin/php /var/www/vhosts/mixdinternet.com.br/app2.com.br/artisan schedule:run`

This pull request, make the 'php artisan queue:work' run with the version that schedule:run was executed


