### PR TITLE
Fixed return type error in ContentsManager

### DIFF
--- a/src/PidsFile/ContentsManager.php
+++ b/src/PidsFile/ContentsManager.php
@@ -70,10 +70,16 @@ class ContentsManager
             return [];
         }
 
-        return json_decode(
+        $fileContents = json_decode(
             (string) file_get_contents($this->getPidsFilePath()),
             true
         );
+
+        if (!\is_array($fileContents)) {
+            return [];
+        }
+
+        return $fileContents;
     }
 
     /** @param array<string, array<int>> $contents */


### PR DESCRIPTION
Fixed an error where getFileContents would return null instead of an array